### PR TITLE
Handle tabs of same route but different parameters

### DIFF
--- a/src/ui-router-tabs.js
+++ b/src/ui-router-tabs.js
@@ -58,8 +58,8 @@ angular.module('ui.router.tabs').directive('tabs', ['$rootScope', '$state',
             $state.go(route, params, options);
           };
 
-          $scope.active = function(route) {
-            var isAncestorOfCurrentRoute = $state.includes(route);
+          $scope.active = function(route, params, options) {
+            var isAncestorOfCurrentRoute = $state.includes(route, params, options);
             return isAncestorOfCurrentRoute;
           };
 
@@ -67,9 +67,9 @@ angular.module('ui.router.tabs').directive('tabs', ['$rootScope', '$state',
 
             // sets which tab is active (used for highlighting)
             angular.forEach($scope.tabs, function(tab) {
-              tab.active = $scope.active(tab.route);
               tab.params = tab.params || {};
               tab.options = tab.options || {};
+              tab.active = $scope.active(tab.route, tab.params, tab.options);
 
               if (tab.active) {
                 $scope.current_tab = tab;


### PR DESCRIPTION
Fix a bug of failure to handle multiple tabs of the same route but different parameters or options.

The bug has caused the `active` class cannot be set correctly when there are tabs of the same route but different parameters.