### PR TITLE
prevent race condition that incorrectly redirects to the default tab som...

### DIFF
--- a/src/ui-router-tabs.js
+++ b/src/ui-router-tabs.js
@@ -88,13 +88,15 @@ angular.module('ui.router.tabs').directive('tabs', ['$rootScope', '$state',
           };
 
           // initialise tabs when creating the directive
-          $scope.update_tabs();
+		  if($state.current.name) {
+			$scope.update_tabs();
 
-          // if none are active, set the default
-          if (!$scope.current_tab) {
-            $scope.current_tab = $scope.tabs[0];
-            $scope.go($scope.current_tab.route, $scope.current_tab.params, $scope.current_tab.options);
-          }
+			// if none are active, set the default
+			if (!$scope.current_tab) {
+			  $scope.current_tab = $scope.tabs[0];
+			  $scope.go($scope.current_tab.route, $scope.current_tab.params, $scope.current_tab.options);
+			}
+		  }
     }],
       templateUrl: function(element, attributes) {
         return attributes.templateUrl || 'ui-router-tabs-default-template.html';


### PR DESCRIPTION
...etimes

Attempts to fix https://github.com/rpocklin/ui-router-tabs/issues/15

This breaks the unit test `it('should route to the first entry in tabConfiguration array by default'...)` but the my app and the example app both appear to work correctly with the change. I'm not sure how to fix the test: it seems events fire differently in a regular browser?