### PR TITLE
Fix main path for Require.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description":  "Idiot-proof tab panes with route support using Angular.js + Bootstrap 3 + UI Router.",
   "homepage":"https://github.com/rpocklin/angular-timeline",
   "author":"Robert Pocklington <rpocklin@gmail.com>",
+  "main": "src/ui-router-tabs.js",
   "repository": {
     "type": "git",
     "url": "http://github.com/rpocklin/angular-timeline"


### PR DESCRIPTION
This is need for require.js. If you installed it with npm, and include with `require('ui-router-tabs')`, require can't find the source file.