### PR TITLE
Migrate to ui-router 1.x $transitions API

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "angular": "^1.4.0",
     "angular-bootstrap": "^1.2.1",
-    "angular-ui-router": "^0.2.14",
+    "angular-ui-router": "^1.0.3",
     "angular-sanitize": "^1.4.0"
   },
   "devDependencies": {

--- a/src/ui-router-tabs.js
+++ b/src/ui-router-tabs.js
@@ -26,7 +26,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
 
 angular.module('ui.router.tabs', ['ngSanitize']);
 angular.module('ui.router.tabs').directive(
-  'tabs', ['$rootScope', '$state', function($rootScope, $state) {
+  'tabs', ['$transitions', '$state', function($transitions, $state) {
 
     return {
       restrict: 'E',
@@ -43,15 +43,11 @@ angular.module('ui.router.tabs').directive(
           scope.update_tabs();
         };
 
-        var unbindStateChangeSuccess = $rootScope.$on('$stateChangeSuccess', updateTabs);
-        var unbindStateChangeError = $rootScope.$on('$stateChangeError', updateTabs);
-        var unbindStateChangeCancel = $rootScope.$on('$stateChangeCancel', updateTabs);
-        var unbindStateNotFound = $rootScope.$on('$stateNotFound', updateTabs);
+        var unbindStateChangeSuccess = $transitions.onSuccess({}, updateTabs);
+        var unbindStateChangeError = $transitions.onError({}, updateTabs);
 
         scope.$on('$destroy', unbindStateChangeSuccess);
         scope.$on('$destroy', unbindStateChangeError);
-        scope.$on('$destroy', unbindStateChangeCancel);
-        scope.$on('$destroy', unbindStateNotFound);
       },
       controller: ['$scope', function($scope) {
 

--- a/src/ui-router-tabs.spec.js
+++ b/src/ui-router-tabs.spec.js
@@ -53,12 +53,12 @@ afterEach(function() {
 
 describe('Directive : UI Router : Tabs', function() {
 
-  var root_scope, isolate_scope, scope, directive_scope, view, element, state, sandbox, spy;
+  var transitions, isolate_scope, scope, directive_scope, view, element, state, sandbox, spy;
   var createView, get_current_state, get_current_params;
   var $ngView;
   var params = {};
 
-  beforeEach(inject(function($rootScope, $state, $templateCache) {
+  beforeEach(inject(function($rootScope, $transitions, $state, $templateCache) {
 
     createView = function(html, scope) {
       element = angular.element(view);
@@ -76,7 +76,7 @@ describe('Directive : UI Router : Tabs', function() {
     scope = $rootScope.$new();
     state = $state;
 
-    root_scope = $rootScope;
+    transitions = $transitions;
 
     get_current_state = function() {
       return state.current.name;
@@ -170,7 +170,7 @@ describe('Directive : UI Router : Tabs', function() {
     expect(get_current_state()).not.toEqual(previous_state);
   });
 
-  it('should not change the route or active tab heading if a $stateChangeStart handler cancels the route change', function() {
+  it('should not change the route or active tab heading if a $transitions.onStart handler cancels the route change', function() {
 
     view = '<tabs data="tabConfiguration"></tabs>';
     renderView();
@@ -181,8 +181,8 @@ describe('Directive : UI Router : Tabs', function() {
 
     scope.$apply();
 
-    root_scope.$on('$stateChangeStart', function(event) {
-      event.preventDefault();
+    transitions.onStart({}, function() {
+      return false;
     });
 
     var targetTabIndex = 2;
@@ -195,7 +195,7 @@ describe('Directive : UI Router : Tabs', function() {
     expect(scope.tabConfiguration[initialTabIndex].active).toBeTruthy();
   });
 
-  it('should not change the route or active tab heading if a $stateChangeError event triggers during the route change', function() {
+  it('should not change the route or active tab heading if a state change fails during the route change', function() {
 
     view = '<tabs data="tabConfiguration"></tabs>';
     renderView();
@@ -218,7 +218,7 @@ describe('Directive : UI Router : Tabs', function() {
     expect(scope.tabConfiguration[initialTabIndex].active).toBeTruthy();
   });
 
-  it('should not change the route or active tab heading if a $stateNotFound event triggers during the route change', function() {
+  it('should not change the route or active tab heading if a state is not found during the route change', function() {
 
     view = '<tabs data="tabConfiguration"></tabs>';
     renderView();


### PR DESCRIPTION
Migration of $stateChangeSuccess and $stateChangeError events to new $transitions API from ui-router 1.x, see https://ui-router.github.io/guide/ng1/migrate-to-1_0#state-change-events